### PR TITLE
Give header row middle column

### DIFF
--- a/src/components/ComparisonModal.jsx
+++ b/src/components/ComparisonModal.jsx
@@ -72,6 +72,7 @@ const ComparisonModal = (props) => {
           <tbody>
             <tr>
               <td>{props.currentInfo.name}</td>
+              <td></td>
               <td>{props.compareInfo.name}</td>
             </tr>
             {Object.keys(comparison).map((feature, idx) => {


### PR DESCRIPTION
@tomcernera @kevypark @Qwill this gives all the rows in the modal table the same number of columns.